### PR TITLE
Fixing imports for Helper and SQTextAttribute Swift files. 

### DIFF
--- a/SQRichTextEditor/Classes/Helper.swift
+++ b/SQRichTextEditor/Classes/Helper.swift
@@ -5,7 +5,7 @@
 //  Created by  Jesse on 2019/12/16.
 //
 
-import Foundation
+import UIKit
 
 struct Helper {
     static func hexToRGBColor(hex string: String) -> UIColor {

--- a/SQRichTextEditor/Classes/SQTextAttribute.swift
+++ b/SQRichTextEditor/Classes/SQTextAttribute.swift
@@ -5,7 +5,7 @@
 //  Created by  Jesse on 2019/12/12.
 //
 
-import Foundation
+import UIKit
 
 public class SQTextAttribute: NSObject {
     public var format = SQTextAttributeFormat()


### PR DESCRIPTION
Both need UIKit due to usage of CGFloat and UIColor respectively.